### PR TITLE
#32: Polymorphic dispatch with references

### DIFF
--- a/bundles/org.eclipse.mita.program.tests/src/org/eclipse/mita/program/tests/optionals/OptionalsTest.mita.xt
+++ b/bundles/org.eclipse.mita.program.tests/src/org/eclipse/mita/program/tests/optionals/OptionalsTest.mita.xt
@@ -117,7 +117,13 @@ struct testRef {
 every 1 second {
     let m : testRef?;
     m.doSomething();
+    
+    let n : int16?;
+    n.doSomething();
 }
 
 fn doSomething(msg : testRef?) {
+}
+
+fn doSomething(msg : int16?) {
 }

--- a/bundles/org.eclipse.mita.program.tests/src/org/eclipse/mita/program/tests/references/ReferencesTest.mita.xt
+++ b/bundles/org.eclipse.mita.program.tests/src/org/eclipse/mita/program/tests/references/ReferencesTest.mita.xt
@@ -291,13 +291,13 @@ every 1 second {
     let m : testRef;
     let mRef = &m;
     (&m).doSomething();
-    (&mRef).doSomethingElse();
+    (&mRef).doSomething();
 }
 
 fn doSomething(msg : &testRef) {
 }
 
-fn doSomethingElse(msg : &&testRef) {
+fn doSomething(msg : &&testRef) {
 }
 
 

--- a/bundles/org.eclipse.mita.program/src/org/eclipse/mita/program/linking/OperationsLinker.java
+++ b/bundles/org.eclipse.mita.program/src/org/eclipse/mita/program/linking/OperationsLinker.java
@@ -45,8 +45,8 @@ public class OperationsLinker {
 	protected class PolymorphicComparator implements Comparator<IEObjectDescription> {
 
 		public int compare(IEObjectDescription operation1, IEObjectDescription operation2) {
-			List<Type> parameters1 = operationUserDataHelper.getArgumentTypes(operation1);
-			List<Type> parameters2 = operationUserDataHelper.getArgumentTypes(operation2);
+			List<Type> parameters1 = operationUserDataHelper.getParameterTypes(operation1);
+			List<Type> parameters2 = operationUserDataHelper.getParameterTypes(operation2);
 			
 			if (parameters1.size() > parameters2.size()) {
 				return -1;

--- a/bundles/org.eclipse.mita.program/src/org/eclipse/mita/program/scoping/OperationUserDataHelper.xtend
+++ b/bundles/org.eclipse.mita.program/src/org/eclipse/mita/program/scoping/OperationUserDataHelper.xtend
@@ -18,9 +18,14 @@ import java.util.List
 import org.eclipse.xtext.resource.IEObjectDescription
 import org.yakindu.base.types.Operation
 import org.yakindu.base.types.Type
+import org.yakindu.base.types.inferrer.ITypeSystemInferrer
+import org.yakindu.base.types.inferrer.ITypeSystemInferrer.InferenceResult
 import org.yakindu.base.types.typesystem.ITypeSystem
 
 class OperationUserDataHelper {
+
+	@Inject
+	extension ITypeSystemInferrer inferrer;
 
 	@Inject
 	extension ITypeSystem typesystem;
@@ -39,6 +44,16 @@ class OperationUserDataHelper {
 			}
 			return #[];
 		}
+	}
+	
+	def List<InferenceResult> getParameterInferenceResults(IEObjectDescription operation) {
+		val objOrProxy = operation.EObjectOrProxy;
+		if (objOrProxy instanceof Operation) {
+			if (!objOrProxy.eIsProxy) {
+				return objOrProxy.parameters.map[it.infer]
+			}
+		}
+		return #[];
 	}
 	
 	def isCallable(IEObjectDescription it, List<Type> arguments) {

--- a/bundles/org.eclipse.mita.program/src/org/eclipse/mita/program/scoping/OperationUserDataHelper.xtend
+++ b/bundles/org.eclipse.mita.program/src/org/eclipse/mita/program/scoping/OperationUserDataHelper.xtend
@@ -30,7 +30,7 @@ class OperationUserDataHelper {
 	@Inject
 	extension ITypeSystem typesystem;
 
-	def List<Type> getArgumentTypes(IEObjectDescription operation) {
+	def List<Type> getParameterTypes(IEObjectDescription operation) {
 		val rawTypesArray = operation.typesArray
 		
 		if(rawTypesArray !== null) {
@@ -55,27 +55,6 @@ class OperationUserDataHelper {
 		}
 		return #[];
 	}
-	
-	def isCallable(IEObjectDescription it, List<Type> arguments) {
-		val paramArray = getTypesArray
-		if (paramArray.length == 0) {
-			return false
-		}
-		
-		println("ParamArray " + paramArray)
-		println("arguments " + arguments)
-		
-		return true;
-	}
-
-	def isExtensionTo(IEObjectDescription it, Type contextType) {
-		val paramArray = getTypesArray
-		if (paramArray === null) {
-			return false
-		}
-		val paramTypeName = paramArray.get(0)
-		return contextType.isSubtypeOf(paramTypeName)
-	}
 
 	protected def getTypesArray(IEObjectDescription description) {
 		val params = description.getUserData(ProgramDslResourceDescriptionStrategy.OPERATION_PARAM_TYPES);
@@ -83,14 +62,6 @@ class OperationUserDataHelper {
 			return null
 		}
 		return params.toArray
-	}
-
-	protected def isSubtypeOf(Type subType, String superTypeName) {
-		if (subType.name == superTypeName) {
-			return true
-		}
-		val match = subType.superTypes.findFirst[name == superTypeName]
-		return match !== null
 	}
 
 	protected def toArray(String paramArrayAsString) {

--- a/bundles/org.eclipse.mita.program/src/org/eclipse/mita/program/validation/ProgramNamesAreUniqueValidator.xtend
+++ b/bundles/org.eclipse.mita.program/src/org/eclipse/mita/program/validation/ProgramNamesAreUniqueValidator.xtend
@@ -49,7 +49,7 @@ class ProgramNamesAreUniqueValidator extends AbstractDeclarativeValidator {
 	}
 
 	def protected overridingName(Operation op) {
-		'''«op.name»_«FOR param : op.parameters.filter[!optional] SEPARATOR '_'»«param.type?.name»«ENDFOR»'''.toString
+		'''«op.name»_«FOR param : op.parameters.filter[!optional] SEPARATOR '_'»«param.typeSpecifier?.toString»«ENDFOR»'''.toString
 	}
 
 	@Inject


### PR DESCRIPTION
Fixes #32 

Switched from using `UserData` (which for `reference<MyType>` only holds `reference`) in `OperationsLinker` to resolve the operation instead in order to properly calculate which operation should be linked.