### PR TITLE
Enterprise WPA support in Mita

### DIFF
--- a/bundles/org.eclipse.mita.program/src/org/eclipse/mita/program/inferrer/StaticValueInferrer.xtend
+++ b/bundles/org.eclipse.mita.program/src/org/eclipse/mita/program/inferrer/StaticValueInferrer.xtend
@@ -13,9 +13,9 @@
 
 package org.eclipse.mita.program.inferrer
 
+import org.eclipse.emf.ecore.EObject
 import org.eclipse.mita.program.ValueRange
 import org.eclipse.mita.program.VariableDeclaration
-import org.eclipse.emf.ecore.EObject
 import org.yakindu.base.expressions.expressions.BoolLiteral
 import org.yakindu.base.expressions.expressions.DoubleLiteral
 import org.yakindu.base.expressions.expressions.ElementReferenceExpression
@@ -25,6 +25,7 @@ import org.yakindu.base.expressions.expressions.IntLiteral
 import org.yakindu.base.expressions.expressions.NumericalUnaryExpression
 import org.yakindu.base.expressions.expressions.PrimitiveValueExpression
 import org.yakindu.base.expressions.expressions.StringLiteral
+import org.yakindu.base.types.Enumerator
 
 /**
  * Infers the value of an expression at compile time.
@@ -51,6 +52,10 @@ class StaticValueInferrer {
 		return expression.value;
 	}
 	
+	static dispatch def Object infer(Enumerator expression, (EObject) => void inferenceBlockerAcceptor) {
+		return expression;
+	}
+		
 	static dispatch def Object infer(NumericalUnaryExpression expression, (EObject) => void inferenceBlockerAcceptor) {
 		val inner = expression.operand.infer(inferenceBlockerAcceptor);
 		if(inner === null || !(inner instanceof Integer || inner instanceof Float)) {
@@ -85,7 +90,7 @@ class StaticValueInferrer {
 			return expression.initialization?.infer(inferenceBlockerAcceptor);
 		}
 	}
-	
+		
 	static dispatch def Object infer(ValueRange expression, (EObject) => void inferenceBlockerAcceptor) {
 		val lower = expression.lowerBound?.infer(inferenceBlockerAcceptor);
 		if(expression.lowerBound !== null && lower === null) return null;

--- a/platforms/org.eclipse.mita.platform.xdk110/1.0.0/xdk110.platform
+++ b/platforms/org.eclipse.mita.platform.xdk110/1.0.0/xdk110.platform
@@ -392,8 +392,9 @@ connectivity named-singleton WLAN {
      */
     required configuration-item psk : string
     
-    required configuration-item enterprise : bool
-
+    required configuration-item enterprise : bool //todo add doc
+    configuration-item IsHostPgmEnabled : bool //todo add doc
+    configuration-item  Username : string //todo add doc
     /**
      * If true we'll attempt to configure the wireless interface using DHCP and
      * all static settings will be ignored. If false, the static settings have to
@@ -432,7 +433,7 @@ connectivity named-singleton WLAN {
      * is recommended.
      */
     configuration-item staticMask : string
-
+    
 }
 
 exception MqttException;

--- a/platforms/org.eclipse.mita.platform.xdk110/1.0.0/xdk110.platform
+++ b/platforms/org.eclipse.mita.platform.xdk110/1.0.0/xdk110.platform
@@ -404,7 +404,7 @@ connectivity named-singleton WLAN {
     /**
      * The username of the WLAN network we want to connect to.
      */    
-    configuration-item  Username : string
+    configuration-item  userName : string
     /**
      * If true we'll attempt to configure the wireless interface using DHCP and
      * all static settings will be ignored. If false, the static settings have to

--- a/platforms/org.eclipse.mita.platform.xdk110/1.0.0/xdk110.platform
+++ b/platforms/org.eclipse.mita.platform.xdk110/1.0.0/xdk110.platform
@@ -401,7 +401,7 @@ connectivity named-singleton WLAN {
      * Make sure to update service pack of the WiFi and then upload the certificate.
      * Certificate must placed under XDK110/common/certs/XDKDummy.
      */
-    configuration-item IsHostPgmEnabled : bool
+    configuration-item isHostPgmEnabled : bool
     
     /**
      * The username of the WLAN network we want to connect to.

--- a/platforms/org.eclipse.mita.platform.xdk110/1.0.0/xdk110.platform
+++ b/platforms/org.eclipse.mita.platform.xdk110/1.0.0/xdk110.platform
@@ -373,12 +373,21 @@ sensor Button {
 	event released
 }
 
+enum ConnectivityType {
+	Personal,
+	Enterprise
+}
 /**
  * Specifies the connection to a wireless wide-area network, also refered to as WiFi. 
  */
 connectivity named-singleton WLAN {
     generator "org.eclipse.mita.platform.xdk110.connectivity.WlanGenerator"
     validator "org.eclipse.mita.platform.xdk110.connectivity.WlanValidator"
+
+    /**
+     * Choose personal WPA connection or Enterprise WPA connection
+     */    
+    required configuration-item connection : ConnectivityType
 
     /**
      * The SSID of the WLAN network we want to connect to.
@@ -390,12 +399,7 @@ connectivity named-singleton WLAN {
      * setting implies WPA2-PSK as authentication method.
      */
     required configuration-item psk : string
-    
-    /**
-     * If true we'll establish enterprise WLAN connectivity. If false, personal WLAN connectivity.
-     */    
-    required configuration-item enterprise : bool
-    
+       
     /**
      * If true server certificate will be uploaded to the WiFi chip CC3100. 
      * Make sure to update service pack of the WiFi and then upload the certificate.

--- a/platforms/org.eclipse.mita.platform.xdk110/1.0.0/xdk110.platform
+++ b/platforms/org.eclipse.mita.platform.xdk110/1.0.0/xdk110.platform
@@ -387,14 +387,24 @@ connectivity named-singleton WLAN {
 
     /**
      * The pre-shared key of the WLAN we're connecting to. Note that this
-     * setting implies WPA2-PSK as authentication method. At this moment
-     * the WLAN connectivity does not support enterprise WLAN.
+     * setting implies WPA2-PSK as authentication method.
      */
     required configuration-item psk : string
     
-    required configuration-item enterprise : bool //todo add doc
-    configuration-item IsHostPgmEnabled : bool //todo add doc
-    configuration-item  Username : string //todo add doc
+    /**
+     * If true we'll establish enterprise WLAN connectivity. If false, personal WLAN connectivity.
+     */    
+    required configuration-item enterprise : bool
+    
+    /**
+     * If true certificate will be uploaded for WiFi chip.
+     */
+    configuration-item IsHostPgmEnabled : bool
+    
+    /**
+     * The username of the WLAN network we want to connect to.
+     */    
+    configuration-item  Username : string
     /**
      * If true we'll attempt to configure the wireless interface using DHCP and
      * all static settings will be ignored. If false, the static settings have to
@@ -433,7 +443,6 @@ connectivity named-singleton WLAN {
      * is recommended.
      */
     configuration-item staticMask : string
-    
 }
 
 exception MqttException;

--- a/platforms/org.eclipse.mita.platform.xdk110/1.0.0/xdk110.platform
+++ b/platforms/org.eclipse.mita.platform.xdk110/1.0.0/xdk110.platform
@@ -391,6 +391,8 @@ connectivity named-singleton WLAN {
      * the WLAN connectivity does not support enterprise WLAN.
      */
     required configuration-item psk : string
+    
+    required configuration-item enterprise : bool
 
     /**
      * If true we'll attempt to configure the wireless interface using DHCP and

--- a/platforms/org.eclipse.mita.platform.xdk110/1.0.0/xdk110.platform
+++ b/platforms/org.eclipse.mita.platform.xdk110/1.0.0/xdk110.platform
@@ -397,7 +397,9 @@ connectivity named-singleton WLAN {
     required configuration-item enterprise : bool
     
     /**
-     * If true certificate will be uploaded for WiFi chip.
+     * If true server certificate will be uploaded to the WiFi chip CC3100. 
+     * Make sure to update service pack of the WiFi and then upload the certificate.
+     * Certificate must placed under XDK110/common/certs/XDKDummy.
      */
     configuration-item IsHostPgmEnabled : bool
     

--- a/platforms/org.eclipse.mita.platform.xdk110/src/org/eclipse/mita/platform/xdk110/connectivity/WlanGenerator.xtend
+++ b/platforms/org.eclipse.mita.platform.xdk110/src/org/eclipse/mita/platform/xdk110/connectivity/WlanGenerator.xtend
@@ -69,16 +69,22 @@ class WlanGenerator extends AbstractSystemResourceGenerator {
 	
 		«IF configuration.getBoolean("enterprise")»
 		«loggingGenerator.generateLogStatement(LogLevel.Info, "Connecting to enterprise network: %s", codeFragmentProvider.create('''NETWORK_SSID'''))»
-		«IF configuration.getBoolean("IsHostPgmEnabled")»
+		«IF configuration.getBoolean("isHostPgmEnabled")»
 		«loggingGenerator.generateLogStatement(LogLevel.Info, "Connecting to enterprise network with host programming")»
 		retcode = WLANHostPgm_Enable();
+		if(RETCODE_OK != retcode)
+		{
+			return retcode;
+		}
+
 		/* disable server authentication */
 		unsigned char pValues;
 		pValues = 0; //0 - Disable the server authentication | 1 - Enable (this is the default)
 		if (0U != sl_WlanSet(SL_WLAN_CFG_GENERAL_PARAM_ID, 19, 1, &pValues))
 		{
-		    return RETCODE(RETCODE_SEVERITY_ERROR, RETCODE_WLAN_SL_SET_FAILED);
+			return RETCODE(RETCODE_SEVERITY_ERROR, RETCODE_WLAN_SL_SET_FAILED);
 		}
+
 		/* Passing NULL as onConnection callback (last parameter) makes this a blocking call, i.e. the
 		 * WlanConnect_EnterpriseWPA function will return only once a connection to the WLAN has been established,
 		 * or if something went wrong while trying to do so. If you wanted non-blocking behavior, pass

--- a/platforms/org.eclipse.mita.platform.xdk110/src/org/eclipse/mita/platform/xdk110/connectivity/WlanGenerator.xtend
+++ b/platforms/org.eclipse.mita.platform.xdk110/src/org/eclipse/mita/platform/xdk110/connectivity/WlanGenerator.xtend
@@ -67,17 +67,23 @@ class WlanGenerator extends AbstractSystemResourceGenerator {
 			return retcode;
 		}
 		«ENDIF»
-		
-		«loggingGenerator.generateLogStatement(LogLevel.Info, "Connecting to %s", codeFragmentProvider.create('''NETWORK_SSID'''))»
+	
+		«IF configuration.getBoolean("enterprise")»
+		«loggingGenerator.generateLogStatement(LogLevel.Info, "Connecting to enterprise network: %s", codeFragmentProvider.create('''NETWORK_SSID'''))»
+		check
+		«ELSE»
 		/* Passing NULL as onConnection callback (last parameter) makes this a blocking call, i.e. the
 		 * WlanConnect_WPA function will return only once a connection to the WLAN has been established,
 		 * or if something went wrong while trying to do so. If you wanted non-blocking behavior, pass
 		 * a callback instead of NULL. */
+		 «loggingGenerator.generateLogStatement(LogLevel.Info, "Connecting to personal network: %s", codeFragmentProvider.create('''NETWORK_SSID'''))»
 		retcode = WlanConnect_WPA((WlanConnect_SSID_T) NETWORK_SSID, (WlanConnect_PassPhrase_T) NETWORK_PSK, NULL);
 		if(RETCODE_OK != retcode)
 		{
 			return retcode;
 		}
+		«ENDIF»
+
 		
 		NetworkConfig_IpSettings_T currentIpSettings;
 		retcode = NetworkConfig_GetIpSettings(&currentIpSettings);
@@ -106,6 +112,7 @@ class WlanGenerator extends AbstractSystemResourceGenerator {
 		.setPreamble('''
 		#define NETWORK_SSID "«configuration.getString("ssid")»"
 		#define NETWORK_PSK  "«configuration.getString("psk")»"
+		#define NETWORK_USERNAME  "«configuration.getString("username")»"
 		''')
 		.addHeader('BCDS_Basics.h', true, IncludePath.VERY_HIGH_PRIORITY)
 		.addHeader('BCDS_WlanConnect.h', true, IncludePath.HIGH_PRIORITY)

--- a/platforms/org.eclipse.mita.platform.xdk110/src/org/eclipse/mita/platform/xdk110/connectivity/WlanGenerator.xtend
+++ b/platforms/org.eclipse.mita.platform.xdk110/src/org/eclipse/mita/platform/xdk110/connectivity/WlanGenerator.xtend
@@ -69,10 +69,8 @@ class WlanGenerator extends AbstractSystemResourceGenerator {
 	
 		«IF configuration.getBoolean("enterprise")»
 		«loggingGenerator.generateLogStatement(LogLevel.Info, "Connecting to enterprise network: %s", codeFragmentProvider.create('''NETWORK_SSID'''))»
-
-	 	«IF configuration.getBoolean("IsHostPgmEnabled")»
-	 	«loggingGenerator.generateLogStatement(LogLevel.Info, "Connecting to enterprise network with host programming")»
-
+		«IF configuration.getBoolean("IsHostPgmEnabled")»
+		«loggingGenerator.generateLogStatement(LogLevel.Info, "Connecting to enterprise network with host programming")»
 		retcode = WLANHostPgm_Enable();
 		/* disable server authentication */
 		unsigned char pValues;
@@ -91,16 +89,15 @@ class WlanGenerator extends AbstractSystemResourceGenerator {
 		{
 			return retcode;
 		}
-	 	«ELSE»
+		«ELSE»
 		«loggingGenerator.generateLogStatement(LogLevel.Info, "Connecting to enterprise network without host programming")»
-	 	«ENDIF»
-
+		«ENDIF»
 		«ELSE»
 		/* Passing NULL as onConnection callback (last parameter) makes this a blocking call, i.e. the
 		 * WlanConnect_WPA function will return only once a connection to the WLAN has been established,
 		 * or if something went wrong while trying to do so. If you wanted non-blocking behavior, pass
 		 * a callback instead of NULL. */
-		 «loggingGenerator.generateLogStatement(LogLevel.Info, "Connecting to personal network: %s", codeFragmentProvider.create('''NETWORK_SSID'''))»
+		«loggingGenerator.generateLogStatement(LogLevel.Info, "Connecting to personal network: %s", codeFragmentProvider.create('''NETWORK_SSID'''))»
 		retcode = WlanConnect_WPA((WlanConnect_SSID_T) NETWORK_SSID, (WlanConnect_PassPhrase_T) NETWORK_PSK, NULL);
 		if(RETCODE_OK != retcode)
 		{

--- a/platforms/org.eclipse.mita.platform.xdk110/src/org/eclipse/mita/platform/xdk110/connectivity/WlanGenerator.xtend
+++ b/platforms/org.eclipse.mita.platform.xdk110/src/org/eclipse/mita/platform/xdk110/connectivity/WlanGenerator.xtend
@@ -71,6 +71,8 @@ class WlanGenerator extends AbstractSystemResourceGenerator {
 		«loggingGenerator.generateLogStatement(LogLevel.Info, "Connecting to enterprise network: %s", codeFragmentProvider.create('''NETWORK_SSID'''))»
 
 	 	«IF configuration.getBoolean("IsHostPgmEnabled")»
+	 	«loggingGenerator.generateLogStatement(LogLevel.Info, "Connecting to enterprise network with host programming")»
+
 		retcode = WLANHostPgm_Enable();
 		/* disable server authentication */
 		unsigned char pValues;
@@ -80,12 +82,11 @@ class WlanGenerator extends AbstractSystemResourceGenerator {
 		    return RETCODE(RETCODE_SEVERITY_ERROR, RETCODE_WLAN_SL_SET_FAILED);
 		}
 		/* Passing NULL as onConnection callback (last parameter) makes this a blocking call, i.e. the
-		 * WlanConnect_WPA function will return only once a connection to the WLAN has been established,
+		 * WlanConnect_EnterpriseWPA function will return only once a connection to the WLAN has been established,
 		 * or if something went wrong while trying to do so. If you wanted non-blocking behavior, pass
 		 * a callback instead of NULL. */
-		«loggingGenerator.generateLogStatement(LogLevel.Info, "Connecting to personal network: %s", codeFragmentProvider.create('''NETWORK_SSID'''))»
+
 		retcode = WlanConnect_EnterpriseWPA((WlanConnect_SSID_T) NETWORK_SSID, (WlanConnect_Username_T) NETWORK_USERNAME, (WlanConnect_PassPhrase_T) NETWORK_PSK, NULL);
-«««		retcode = WlanConnect_WPA((WlanConnect_SSID_T) NETWORK_SSID, (WlanConnect_PassPhrase_T) NETWORK_PSK, NULL);
 		if(RETCODE_OK != retcode)
 		{
 			return retcode;

--- a/platforms/org.eclipse.mita.platform.xdk110/src/org/eclipse/mita/platform/xdk110/connectivity/WlanGenerator.xtend
+++ b/platforms/org.eclipse.mita.platform.xdk110/src/org/eclipse/mita/platform/xdk110/connectivity/WlanGenerator.xtend
@@ -83,11 +83,14 @@ class WlanGenerator extends AbstractSystemResourceGenerator {
 		 * WlanConnect_EnterpriseWPA function will return only once a connection to the WLAN has been established,
 		 * or if something went wrong while trying to do so. If you wanted non-blocking behavior, pass
 		 * a callback instead of NULL. */
-
 		retcode = WlanConnect_EnterpriseWPA((WlanConnect_SSID_T) NETWORK_SSID, (WlanConnect_Username_T) NETWORK_USERNAME, (WlanConnect_PassPhrase_T) NETWORK_PSK, NULL);
 		if(RETCODE_OK != retcode)
 		{
 			return retcode;
+		}
+		else
+		{
+			vTaskDelay(pdMS_TO_TICKS(1000));
 		}
 		«ELSE»
 		«loggingGenerator.generateLogStatement(LogLevel.Info, "Connecting to enterprise network without host programming")»

--- a/platforms/org.eclipse.mita.platform.xdk110/src/org/eclipse/mita/platform/xdk110/connectivity/WlanGenerator.xtend
+++ b/platforms/org.eclipse.mita.platform.xdk110/src/org/eclipse/mita/platform/xdk110/connectivity/WlanGenerator.xtend
@@ -66,17 +66,30 @@ class WlanGenerator extends AbstractSystemResourceGenerator {
 			return retcode;
 		}
 		«ENDIF»
-	
-		«IF configuration.getBoolean("enterprise")»
-		«loggingGenerator.generateLogStatement(LogLevel.Info, "Connecting to enterprise network: %s", codeFragmentProvider.create('''NETWORK_SSID'''))»
+
+		«IF configuration.getEnumerator("connection").name == "Personal"»
+		/* Passing NULL as onConnection callback (last parameter) makes this a blocking call, i.e. the
+		 * WlanConnect_WPA function will return only once a connection to the WLAN has been established,
+		 * or if something went wrong while trying to do so. If you wanted non-blocking behavior, pass
+		 * a callback instead of NULL. */
+		«loggingGenerator.generateLogStatement(LogLevel.Info, "Connecting to personal network: %s", codeFragmentProvider.create('''NETWORK_SSID'''))»
+		retcode = WlanConnect_WPA((WlanConnect_SSID_T) NETWORK_SSID, (WlanConnect_PassPhrase_T) NETWORK_PSK, NULL);
+		if(RETCODE_OK != retcode)
+		{
+			return retcode;
+		}
+		«ELSEIF configuration.getEnumerator("connection").name == "Enterprise"»
 		«IF configuration.getBoolean("isHostPgmEnabled")»
-		«loggingGenerator.generateLogStatement(LogLevel.Info, "Connecting to enterprise network with host programming")»
+		«loggingGenerator.generateLogStatement(LogLevel.Info, "Connecting to enterprise network with host programming: %s", codeFragmentProvider.create('''NETWORK_SSID'''))»
 		retcode = WLANHostPgm_Enable();
 		if(RETCODE_OK != retcode)
 		{
 			return retcode;
 		}
-
+		«ELSE»
+		«loggingGenerator.generateLogStatement(LogLevel.Info, "Connecting to enterprise network without host programming: %s", codeFragmentProvider.create('''NETWORK_SSID'''))»
+		«ENDIF»
+		
 		/* disable server authentication */
 		unsigned char pValues;
 		pValues = 0; //0 - Disable the server authentication | 1 - Enable (this is the default)
@@ -99,19 +112,7 @@ class WlanGenerator extends AbstractSystemResourceGenerator {
 			vTaskDelay(pdMS_TO_TICKS(1000));
 		}
 		«ELSE»
-		«loggingGenerator.generateLogStatement(LogLevel.Info, "Connecting to enterprise network without host programming")»
-		«ENDIF»
-		«ELSE»
-		/* Passing NULL as onConnection callback (last parameter) makes this a blocking call, i.e. the
-		 * WlanConnect_WPA function will return only once a connection to the WLAN has been established,
-		 * or if something went wrong while trying to do so. If you wanted non-blocking behavior, pass
-		 * a callback instead of NULL. */
-		«loggingGenerator.generateLogStatement(LogLevel.Info, "Connecting to personal network: %s", codeFragmentProvider.create('''NETWORK_SSID'''))»
-		retcode = WlanConnect_WPA((WlanConnect_SSID_T) NETWORK_SSID, (WlanConnect_PassPhrase_T) NETWORK_PSK, NULL);
-		if(RETCODE_OK != retcode)
-		{
-			return retcode;
-		}
+		«loggingGenerator.generateLogStatement(LogLevel.Info, "Invalid connection type")»
 		«ENDIF»
 
 		NetworkConfig_IpSettings_T currentIpSettings;

--- a/platforms/org.eclipse.mita.platform.xdk110/src/org/eclipse/mita/platform/xdk110/connectivity/WlanValidator.xtend
+++ b/platforms/org.eclipse.mita.platform.xdk110/src/org/eclipse/mita/platform/xdk110/connectivity/WlanValidator.xtend
@@ -77,11 +77,11 @@ class WlanValidator implements IResourceValidator {
 		} else {
 			StaticValueInferrer.infer(enterpriseConfigItem.value, []) as Boolean;
 		}
-		
+
 		if(useEnterprise) {
-			val enterpriseHost = setup.configurationItemValues.findFirst[ it.item.name == "IsHostPgmEnabled" ];
+			val enterpriseHost = setup.configurationItemValues.findFirst[ it.item.name == "isHostPgmEnabled" ];
 			if(enterpriseHost === null) {
-				acceptor.acceptError("With enterprise set true, IsHostPgmEnabled must be configured", setup, ProgramPackage.Literals.SYSTEM_RESOURCE_SETUP__TYPE, 0, "network_IsHostPgmEnabled_not_conf");
+				acceptor.acceptError("With enterprise set true, isHostPgmEnabled must be configured", setup, ProgramPackage.Literals.SYSTEM_RESOURCE_SETUP__TYPE, 0, "network_IsHostPgmEnabled_not_conf");
 			}
 			val userName = setup.configurationItemValues.findFirst[ it.item.name == "userName" ];
 			if(userName === null) {

--- a/platforms/org.eclipse.mita.platform.xdk110/src/org/eclipse/mita/platform/xdk110/connectivity/WlanValidator.xtend
+++ b/platforms/org.eclipse.mita.platform.xdk110/src/org/eclipse/mita/platform/xdk110/connectivity/WlanValidator.xtend
@@ -31,6 +31,7 @@ class WlanValidator implements IResourceValidator {
 	override validate(Program program, EObject context, ValidationMessageAcceptor acceptor) {
 		if(context instanceof SystemResourceSetup) {
 			validateNetworkConfig(context, acceptor);
+			validateEnterprise(context, acceptor);
 		}
 	}
 	
@@ -69,4 +70,23 @@ class WlanValidator implements IResourceValidator {
 		
 	}
 	
+	protected def validateEnterprise(SystemResourceSetup setup, ValidationMessageAcceptor acceptor) {
+		val enterpriseConfigItem = setup.configurationItemValues.findFirst[ it.item.name == "enterprise" ];
+		val useEnterprise = if(enterpriseConfigItem === null) {
+			true
+		} else {
+			StaticValueInferrer.infer(enterpriseConfigItem.value, []) as Boolean;
+		}
+		
+		if(useEnterprise) {
+			val enterpriseHost = setup.configurationItemValues.findFirst[ it.item.name == "IsHostPgmEnabled" ];
+			if(enterpriseHost === null) {
+				acceptor.acceptError("With enterprise set true, IsHostPgmEnabled must be configured", setup, ProgramPackage.Literals.SYSTEM_RESOURCE_SETUP__TYPE, 0, "network_IsHostPgmEnabled_not_conf");
+			}
+			val userName = setup.configurationItemValues.findFirst[ it.item.name == "userName" ];
+			if(userName === null) {
+				acceptor.acceptError("With enterprise set true, userName must be configured", setup, ProgramPackage.Literals.SYSTEM_RESOURCE_SETUP__TYPE, 0, "network_userName_not_conf");
+			}
+		}
+	}
 }

--- a/platforms/org.eclipse.mita.platform.xdk110/src/org/eclipse/mita/platform/xdk110/connectivity/WlanValidator.xtend
+++ b/platforms/org.eclipse.mita.platform.xdk110/src/org/eclipse/mita/platform/xdk110/connectivity/WlanValidator.xtend
@@ -21,6 +21,10 @@ import org.eclipse.mita.program.validation.IResourceValidator
 import java.util.regex.Pattern
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.xtext.validation.ValidationMessageAcceptor
+import java.util.Enumeration
+import org.eclipse.xtext.xbase.scoping.featurecalls.StaticImplicitMethodsFeatureForTypeProvider.ExtensionClassNameProvider
+import org.eclipse.xtext.serializer.sequencer.ITransientValueService.ValueTransient
+import org.yakindu.base.types.Enumerator
 
 class WlanValidator implements IResourceValidator {
 	
@@ -31,7 +35,7 @@ class WlanValidator implements IResourceValidator {
 	override validate(Program program, EObject context, ValidationMessageAcceptor acceptor) {
 		if(context instanceof SystemResourceSetup) {
 			validateNetworkConfig(context, acceptor);
-			validateEnterprise(context, acceptor);
+			validateConnectivityType(context, acceptor);
 		}
 	}
 	
@@ -70,23 +74,24 @@ class WlanValidator implements IResourceValidator {
 		
 	}
 	
-	protected def validateEnterprise(SystemResourceSetup setup, ValidationMessageAcceptor acceptor) {
-		val enterpriseConfigItem = setup.configurationItemValues.findFirst[ it.item.name == "enterprise" ];
-		val useEnterprise = if(enterpriseConfigItem === null) {
-			true
-		} else {
-			StaticValueInferrer.infer(enterpriseConfigItem.value, []) as Boolean;
+	protected def validateConnectivityType(SystemResourceSetup setup, ValidationMessageAcceptor acceptor) {
+		
+		val connectivityConfigItem = setup.configurationItemValues.findFirst[x | x.item.name == 'connection'];
+		val enterpriseOrPersonal = StaticValueInferrer.infer(connectivityConfigItem.value, []);
+		if(enterpriseOrPersonal instanceof Enumerator) {
+			if(enterpriseOrPersonal.name == "Enterprise") {
+				val enterpriseHost = setup.configurationItemValues.findFirst[ it.item.name == "isHostPgmEnabled" ];
+				if(enterpriseHost === null) {
+					acceptor.acceptError("With enterprise set true, isHostPgmEnabled must be configured", connectivityConfigItem, ProgramPackage.Literals.CONFIGURATION_ITEM_VALUE__VALUE, 0, "network_IsHostPgmEnabled_not_conf");
+				}
+				val userName = setup.configurationItemValues.findFirst[ it.item.name == "userName" ];
+				if(userName === null) {
+					acceptor.acceptError("With enterprise set true, userName must be configured", connectivityConfigItem, ProgramPackage.Literals.CONFIGURATION_ITEM_VALUE__VALUE, 0, "network_userName_not_conf");
+				}
+			}	
 		}
-
-		if(useEnterprise) {
-			val enterpriseHost = setup.configurationItemValues.findFirst[ it.item.name == "isHostPgmEnabled" ];
-			if(enterpriseHost === null) {
-				acceptor.acceptError("With enterprise set true, isHostPgmEnabled must be configured", setup, ProgramPackage.Literals.SYSTEM_RESOURCE_SETUP__TYPE, 0, "network_IsHostPgmEnabled_not_conf");
-			}
-			val userName = setup.configurationItemValues.findFirst[ it.item.name == "userName" ];
-			if(userName === null) {
-				acceptor.acceptError("With enterprise set true, userName must be configured", setup, ProgramPackage.Literals.SYSTEM_RESOURCE_SETUP__TYPE, 0, "network_userName_not_conf");
-			}
+		else {
+			acceptor.acceptError("We should never get here", setup, null, 0, null);
 		}
 	}
 }

--- a/platforms/org.eclipse.mita.platform.xdk110/src/org/eclipse/mita/platform/xdk110/platform/MakefileGenerator.xtend
+++ b/platforms/org.eclipse.mita.platform.xdk110/src/org/eclipse/mita/platform/xdk110/platform/MakefileGenerator.xtend
@@ -44,21 +44,6 @@ class MakefileGenerator implements IPlatformMakefileGenerator {
 		#export BCDS_CFLAGS_COMMON = 
 		
 		
-		# This variable should fully specify the build configuration of the Serval 
-		# Stack library with regards the enabled and disabled features for the HTTPS Using TLS. 
-		export SERVAL_ENABLE_TLS_CLIENT=1
-		export SERVAL_ENABLE_TLS_ECC=1
-		export SERVAL_ENABLE_TLS_PSK=0
-		export SERVAL_ENABLE_DTLS_PSK=0
-		export SERVAL_ENABLE_DTLS_ECC=1
-		export SERVAL_MAX_NUM_MESSAGES=8
-		export SERVAL_MAX_SIZE_APP_PACKET=900
-		export SERVAL_ENABLE_TLS=1
-		export EscTls_CIPHER_SUITE=TLS_RSA_WITH_AES_128_CBC_SHA
-		
-		export BCDS_SERVALSTACK_MACROS = \
-			-D SERVAL_CYCURTLS_HANDSHAKE_BUFFER_SIZE=5500
-		
 		#List all the application header file under variable BCDS_XDK_INCLUDES 
 		export BCDS_XDK_INCLUDES = \
 			-I$(BCDS_BASE_DIR)/xdk110/Libraries/BSTLib/3rd-party/bstlib/BMA2x2_driver \

--- a/platforms/org.eclipse.mita.platform.xdk110/src/org/eclipse/mita/platform/xdk110/platform/MakefileGenerator.xtend
+++ b/platforms/org.eclipse.mita.platform.xdk110/src/org/eclipse/mita/platform/xdk110/platform/MakefileGenerator.xtend
@@ -43,12 +43,31 @@ class MakefileGenerator implements IPlatformMakefileGenerator {
 		#and if any addition flags required then add that flags only in the below macro 
 		#export BCDS_CFLAGS_COMMON = 
 		
+		
+		# This variable should fully specify the build configuration of the Serval 
+		# Stack library with regards the enabled and disabled features for the HTTPS Using TLS. 
+		export SERVAL_ENABLE_TLS_CLIENT=1
+		export SERVAL_ENABLE_TLS_ECC=1
+		export SERVAL_ENABLE_TLS_PSK=0
+		export SERVAL_ENABLE_DTLS_PSK=0
+		export SERVAL_ENABLE_DTLS_ECC=1
+		export SERVAL_MAX_NUM_MESSAGES=8
+		export SERVAL_MAX_SIZE_APP_PACKET=900
+		export SERVAL_ENABLE_TLS=1
+		export EscTls_CIPHER_SUITE=TLS_RSA_WITH_AES_128_CBC_SHA
+		
+		export BCDS_SERVALSTACK_MACROS = \
+			-D SERVAL_CYCURTLS_HANDSHAKE_BUFFER_SIZE=5500
+		
 		#List all the application header file under variable BCDS_XDK_INCLUDES 
 		export BCDS_XDK_INCLUDES = \
 			-I$(BCDS_BASE_DIR)/xdk110/Libraries/BSTLib/3rd-party/bstlib/BMA2x2_driver \
 			-I$(BCDS_APP_SOURCE_DIR) \
 			-I$(BCDS_APP_SOURCE_DIR)/.. \
-			-I$(BCDS_APP_SOURCE_DIR)/base
+			-I$(BCDS_APP_SOURCE_DIR)/base \
+			-I$(BCDS_BASE_DIR)/xdk110/Common/include \
+			-I$(BCDS_BASE_DIR)/xdk110/Common/certs/XDKDummy \
+			-I$(BCDS_BASE_DIR)/xdk110/Common/source
 			
 		#List all the application source file under variable BCDS_XDK_APP_SOURCE_FILES in a similar pattern as below
 		export BCDS_XDK_APP_SOURCE_FILES = \


### PR DESCRIPTION
Implemented,

1. Enterprise WPA connection
2. Validated the enterprise arguments

User will have to specify whether he/she wants to use enterprise or personal by setting a flag. Based on the choice, 

- personal WPA connection will require ssid and password as inputs
- enterprise WPA connection will require ssid, password, username and wifi-chip programming as inputs