### PR TITLE
Define parent SumType as super type of a SumAlternative

### DIFF
--- a/bundles/org.eclipse.mita.base/model/types.xcore
+++ b/bundles/org.eclipse.mita.base/model/types.xcore
@@ -211,15 +211,24 @@ class ImportStatement {
 
 class SumType extends ComplexType, Exportable {
 	// I would use features, but if I want to have SumAlternative as a ComplexType (which it is), then I can't make it a Declaration as well
-	contains SumAlternative[] alternatives
+	contains SumAlternative[] alternatives opposite sumType
 	
 	op String toString() {
 		return super.toString();
 	}
 }
 interface SumAlternative extends ComplexType, HasAccessors {
+	container SumType sumType opposite alternatives
+	
 	op Type realType() {
 		return this;
+	}
+	
+	op Type[] getSuperTypes() {
+		if (!super.superTypes.contains(sumType)) {
+			super.superTypes.add(sumType);
+		}
+		return super.superTypes
 	}
 }
 class Singleton extends SumAlternative {

--- a/bundles/org.eclipse.mita.program.tests/src/org/eclipse/mita/program/tests/sumtypes/SumTypesTest.mita.xt
+++ b/bundles/org.eclipse.mita.program.tests/src/org/eclipse/mita/program/tests/sumtypes/SumTypesTest.mita.xt
@@ -158,3 +158,10 @@ fn incVecs(a: anyVec) {
     }
 	return b;
 }
+
+fn testAssignments() {
+    var v3 : anyVec.vec3d = anyVec.vec3d(10, 10, 10);
+    var av : anyVec = anyVec.vec3d(10, 10, 10);
+    // XPECT errors --> "Assignment operator '=' may only be applied on compatible types, not on vec3d and vec1d." at "v3 = anyVec.vec1d(10)"
+    v3 = anyVec.vec1d(10);
+}

--- a/bundles/org.eclipse.mita.program/src/org/eclipse/mita/program/inferrer/ProgramDslTypeInferrer.xtend
+++ b/bundles/org.eclipse.mita.program/src/org/eclipse/mita/program/inferrer/ProgramDslTypeInferrer.xtend
@@ -38,9 +38,7 @@ import org.eclipse.mita.base.types.Operation
 import org.eclipse.mita.base.types.Property
 import org.eclipse.mita.base.types.StructureType
 import org.eclipse.mita.base.types.SumAlternative
-import org.eclipse.mita.base.types.SumType
 import org.eclipse.mita.base.types.TypeParameter
-import org.eclipse.mita.base.types.inferrer.ITypeSystemInferrer.InferenceResult
 import org.eclipse.mita.base.types.typesystem.ITypeSystem
 import org.eclipse.mita.base.types.validation.IValidationIssueAcceptor
 import org.eclipse.mita.base.types.validation.IValidationIssueAcceptor.ListBasedValidationIssueAcceptor
@@ -76,9 +74,9 @@ import static org.eclipse.mita.base.scoping.MitaTypeSystem.ARRAY_TYPE
 import static org.eclipse.mita.base.scoping.MitaTypeSystem.BOOL_TYPE
 import static org.eclipse.mita.base.scoping.MitaTypeSystem.DOUBLE_TYPE
 import static org.eclipse.mita.base.scoping.MitaTypeSystem.FLOAT_TYPE
+import static org.eclipse.mita.base.scoping.MitaTypeSystem.INT32_TYPE
 import static org.eclipse.mita.base.scoping.MitaTypeSystem.MODALITY_TYPE
 import static org.eclipse.mita.base.scoping.MitaTypeSystem.REFERENCE_TYPE
-import static org.eclipse.mita.base.scoping.MitaTypeSystem.INT32_TYPE
 import static org.eclipse.mita.base.scoping.MitaTypeSystem.SIGINST_TYPE
 import static org.eclipse.mita.base.types.typesystem.ITypeSystem.VOID
 
@@ -415,17 +413,9 @@ class ProgramDslTypeInferrer extends ExpressionsTypeInferrer {
 	
 	override doInfer(FeatureCall fc) {
 		if (fc.feature instanceof SumAlternative) {
-			val owner = fc.owner;
-			if(owner instanceof ElementReferenceExpression) {
-				val ref = owner.reference;
-				if(ref instanceof SumType) {
-					return InferenceResult.from(ref);
-				}
-			}
+			return InferenceResult.from(fc.feature as SumAlternative)
 		}
-		else {
-			return super.doInfer(fc);
-		}
+		return super.doInfer(fc);
 	}
 	
 	def doInfer(SystemResourceSetup e) {
@@ -469,7 +459,7 @@ class ProgramDslTypeInferrer extends ExpressionsTypeInferrer {
 				return InferenceResult.from(ref);
 			}
 			else if(ref instanceof SumAlternative) {
-				return InferenceResult.from(ref.eContainer as SumType);
+				return InferenceResult.from(ref);
 			}
 			return super.doInfer(e);
 		}


### PR DESCRIPTION
Fixes #9 

Allows to write this:

```
alt anyVec {
	  vec0d
	| vec1d: int32
	| vec2d: int32, int32
}

fn foo() {
    var y: anyVec.vec2d = anyVec.vec2d(10, 10);
}
```