### PR TITLE
Fresh install of Mita workspace using Oomph fails when calling GenerateTypeDsl.mwe

### DIFF
--- a/mita.setup
+++ b/mita.setup
@@ -107,6 +107,8 @@
       name="${target_definition}"/>
   <setupTask
       xsi:type="projects:ProjectsBuildTask"
+      id="firstBuild"
+      onlyNewProjects="true"
       refresh="true"/>
   <setupTask
       xsi:type="setup:CompoundTask"
@@ -142,7 +144,12 @@
   <setupTask
       xsi:type="launching:LaunchTask"
       id="GenerateTypeDsl"
-      launcher="/org.eclipse.mita.types/GenerateTypeDsl.launch"/>
+      launcher="/org.eclipse.mita.base/GenerateTypeDsl.launch"/>
+  <setupTask
+      xsi:type="projects:ProjectsBuildTask"
+      id="secondBuild"
+      onlyNewProjects="true"
+      refresh="true"/>
   <setupTask
       xsi:type="launching:LaunchTask"
       id="GenerateProgramDsl"
@@ -153,6 +160,8 @@
       launcher="/org.eclipse.mita.platform/GeneratePlatformDSL.launch"/>
   <setupTask
       xsi:type="projects:ProjectsBuildTask"
+      id="finalClean"
+      onlyNewProjects="true"
       clean="true"
       build="false"/>
   <stream name="master"/>


### PR DESCRIPTION
Fixed path for GenerateTypeDsl.launcher

- added refresh & build after generating TypeDsl -> Program- and PlatformDsl will now be generated without NPE
- changed build & clean only for new projects

With this PR the oomph setup should work as described in the readme.

fix #133 

Signed-off-by: rherrmannr <Robin.Herrmann@itemis.com>