### PR TITLE
Invoke make and read error stream for noCompileError tests

### DIFF
--- a/bundles/org.eclipse.mita.program.tests/src/org/eclipse/mita/program/generator/tests/AbstractGeneratorTest.xtend
+++ b/bundles/org.eclipse.mita.program.tests/src/org/eclipse/mita/program/generator/tests/AbstractGeneratorTest.xtend
@@ -14,7 +14,6 @@
 package org.eclipse.mita.program.generator.tests;
 
 import org.eclipse.mita.program.Program
-import org.eclipse.mita.program.tests.util.CProjectHelper
 import org.eclipse.mita.program.tests.util.ProgramDslInjectorProvider
 import com.google.inject.Inject
 import com.google.inject.Provider
@@ -42,6 +41,7 @@ import org.junit.runner.RunWith
 
 import static org.junit.Assert.*
 import org.eclipse.core.runtime.Assert
+import org.eclipse.mita.program.tests.util.TestProjectHelper
 
 @RunWith(XtextRunner)
 @InjectWith(ProgramDslInjectorProvider)
@@ -56,11 +56,11 @@ public class AbstractGeneratorTest {
 	@Inject
 	private Provider<XtextResourceSet> resourceSetProvider;
 
-	@Inject extension CProjectHelper
+	@Inject extension TestProjectHelper
 
 	@Before
 	def void setup() {
-		createEmptyGenerationProject();
+		createEmptyTestProject();
 	}
 
 	/**
@@ -71,7 +71,7 @@ public class AbstractGeneratorTest {
 	 * @throws Exception if something goes wrong (very helpful, isn't it?)
 	 */
 	protected def InMemoryFileSystemAccess generateFrom(CharSequence Mita_code) throws Exception {
-		val project = generationProject;
+		val project = testProject;
 		Assert.isTrue(project.accessible)
 		val appfile = project.getFile("application.mita")
 		if (!appfile.exists) {

--- a/bundles/org.eclipse.mita.program.tests/src/org/eclipse/mita/program/tests/util/ExternalCommandExecutor.java
+++ b/bundles/org.eclipse.mita.program.tests/src/org/eclipse/mita/program/tests/util/ExternalCommandExecutor.java
@@ -1,0 +1,70 @@
+/********************************************************************************
+ * Copyright (c) 2018 itemis AG.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * Contributors:
+ *    itemis AG - initial contribution
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.mita.program.tests.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.List;
+
+public class ExternalCommandExecutor {
+
+	/**
+	 * Executes given commands in given working directory. Reads error stream and
+	 * throws RuntimeException in case of error.
+	 */
+	public void execute(List<String> command, File workingDirectory) throws Exception {
+		ProcessBuilder processBuilder = new ProcessBuilder(command).directory(workingDirectory);
+		Process process = processBuilder.redirectErrorStream(true).start();
+		String message = readProcessInputStream(process);
+
+		boolean wait = true;
+		int exitCode = 0;
+
+		do {
+			wait = false;
+
+			// waiting for the processes termination
+			try {
+				process.waitFor();
+			} catch (InterruptedException e) {
+				// we ignore if waiting was interrupted ...
+			}
+
+			// if we get an exit code then we know that the process is finished
+			try {
+				exitCode = process.exitValue();
+			} catch (IllegalThreadStateException e) {
+				wait = true; // if we get an exception then the process has not finished
+			}
+		} while (wait);
+
+		if (exitCode != 0) {
+
+			throw new RuntimeException("Execution of command '" + String.join(" ", command) + "' failed (exit status "
+					+ process.exitValue() + "):\n" + message);
+		}
+	}
+
+	private String readProcessInputStream(Process process) throws IOException {
+		Reader reader = new InputStreamReader(process.getInputStream());
+		char[] buffer = new char[4096];
+		int count;
+		StringBuilder message = new StringBuilder();
+		while ((count = reader.read(buffer)) != -1) {
+			message.append(buffer, 0, count);
+		}
+		return message.toString();
+	}
+}

--- a/bundles/org.eclipse.mita.program/src/org/eclipse/mita/program/generator/CompilationContext.xtend
+++ b/bundles/org.eclipse.mita.program/src/org/eclipse/mita/program/generator/CompilationContext.xtend
@@ -116,6 +116,11 @@ class CompilationContext {
 		return units.exists[unit | unit.eventHandlers.exists[e| e.event instanceof TimeIntervalEvent ] ]
 	}
 	
+	def hasGlobalVariables() {
+		assertInited();
+		return units.exists[!globalVariables.empty]
+	}
+	
 	def getAllExceptionsUsed() {
 		assertInited();
 		val unitAndStdlibExceptions = (units + stdlib).flatMap[program | 

--- a/bundles/org.eclipse.mita.program/src/org/eclipse/mita/program/generator/GeneratorUtils.xtend
+++ b/bundles/org.eclipse.mita.program/src/org/eclipse/mita/program/generator/GeneratorUtils.xtend
@@ -57,10 +57,9 @@ import org.eclipse.xtext.generator.trace.node.CompositeGeneratorNode
 import org.eclipse.xtext.generator.trace.node.IGeneratorNode
 import org.eclipse.xtext.generator.trace.node.NewLineNode
 import org.eclipse.xtext.generator.trace.node.TextNode
-import org.eclipse.emf.ecore.util.EcoreUtil
 
 /**
- * Utility functions for the generating code. Eventually this will be moved into the model.
+ * Utility functions for generating code. Eventually this will be moved into the model.
  */
 class GeneratorUtils {
 
@@ -427,6 +426,10 @@ class GeneratorUtils {
 	def IGeneratorNode noBraces(IGeneratorNode stmt) {
 		trim(stmt, false, [x|trimBraces(x)]);
 		trim(stmt, true, [x|trimBraces(x)]);
+	}
+	
+	def boolean containsCodeRelevantContent(Program it) {
+		!eventHandlers.empty || !functionDefinitions.empty || !types.empty || !globalVariables.empty
 	}
 
 }

--- a/bundles/org.eclipse.mita.program/src/org/eclipse/mita/program/generator/ProgramDslGenerator.xtend
+++ b/bundles/org.eclipse.mita.program/src/org/eclipse/mita/program/generator/ProgramDslGenerator.xtend
@@ -193,9 +193,7 @@ class ProgramDslGenerator extends AbstractGenerator implements IGeneratorOnResou
 			}
 		}
 	
-		for (program : compilationUnits.filter[x | 
-			!x.eventHandlers.empty || !x.functionDefinitions.empty || !x.types.empty
-		]) {
+		for (program : compilationUnits.filter[containsCodeRelevantContent]) {
 			// generate the actual content for this resource
 			files += fsa.produceFile(userCodeGenerator.getResourceBaseName(program) + '.c', program, stdlib.head.trace.append(userCodeGenerator.generateImplementation(context, program)));
 			files += fsa.produceFile(userCodeGenerator.getResourceBaseName(program) + '.h', program, stdlib.head.trace.append(userCodeGenerator.generateHeader(context, program)));

--- a/bundles/org.eclipse.mita.program/src/org/eclipse/mita/program/generator/internal/EntryPointGenerator.xtend
+++ b/bundles/org.eclipse.mita.program/src/org/eclipse/mita/program/generator/internal/EntryPointGenerator.xtend
@@ -78,7 +78,7 @@ class EntryPointGenerator {
 		for(systemResource : allResourcesUsed) {
 			baseIncludes.add(new IncludePath(systemResource.fileBasename + '.h', false));
 		}
-		for(program : context.allUnits) {
+		for(program : context.allUnits.filter[containsCodeRelevantContent]) {
 			baseIncludes.add(new IncludePath(userCodeGenerator.getResourceBaseName(program) + '.h', false))
 		}
 		
@@ -108,9 +108,10 @@ class EntryPointGenerator {
 				
 				«ENDFOR»
 				«ENDIF»
+				«IF context.hasGlobalVariables»
 				exception = initGlobalVariables();
 				«"InitGlobalVars".generateLoggingExceptionHandler("setup")»
-				
+				«ENDIF»
 				return exception;
 			}
 			

--- a/platforms/org.eclipse.mita.platform.unittest/src/org/eclipse/mita/platform/unittest/MakefileGenerator.xtend
+++ b/platforms/org.eclipse.mita.platform.unittest/src/org/eclipse/mita/platform/unittest/MakefileGenerator.xtend
@@ -27,7 +27,7 @@ class MakefileGenerator implements IPlatformMakefileGenerator {
 	override generateMakefile(Iterable<Program> program, List<String> sourceFiles) {
 		return codeFragmentProvider.create('''
 		export CC=gcc
-		export CCFLAGS=-Wall
+		export CCFLAGS=-Wall -std=c99
 		export BUILDDIR=./build
 		export SOURCE_INCLUDES = -I. -I./base
 		export SOURCE_DIR=.

--- a/platforms/org.eclipse.mita.platform.unittest/src/org/eclipse/mita/platform/unittest/SensorGenerator.xtend
+++ b/platforms/org.eclipse.mita.platform.unittest/src/org/eclipse/mita/platform/unittest/SensorGenerator.xtend
@@ -13,11 +13,11 @@
 
 package org.eclipse.mita.platform.unittest
 
+import com.google.inject.Inject
 import org.eclipse.mita.program.ModalityAccess
 import org.eclipse.mita.program.ModalityAccessPreparation
 import org.eclipse.mita.program.generator.AbstractSystemResourceGenerator
 import org.eclipse.mita.program.generator.CodeFragmentProvider
-import com.google.inject.Inject
 
 class SensorGenerator extends AbstractSystemResourceGenerator {
 	
@@ -33,21 +33,26 @@ class SensorGenerator extends AbstractSystemResourceGenerator {
 	}
 	
 	override generateSetup() {
-		code.create('''setupMock();''')
+		code.create('''// nothing to do''')
 	}
 	
 	override generateEnable() {
-		code.create('''enableMock();''')
+		code.create('''// nothing to do''')
 	}
 	
 	override generateAdditionalHeaderContent() {
 		code.create('''
 			void accessPreparationMock();
 			int16_t modalityAccessMock();
-			void setupMock();
-			void enableMock();	
 		''')
 		.addHeader('stdint.h', true);
 	}
+	
+	override generateAdditionalImplementation() {
+        codeFragmentProvider.create('''
+        void accessPreparationMock() {}
+        int16_t modalityAccessMock() { return 42;}
+        ''')
+    }
 	
 }


### PR DESCRIPTION
This re-activates noCompileError tests. Before that the compile never run because of faulty test project configuration. Now the tests are not dependent on CDT and corresponding project configurations anymore.

Signed-off-by: Thomas Kutz <thomas.kutz@itemis.de>

fixes #47 