### PR TITLE
Only create resource descriptions once per resource

### DIFF
--- a/bundles/org.eclipse.mita.base/src/org/eclipse/mita/base/expressions/inferrer/ExpressionsTypeInferrer.java
+++ b/bundles/org.eclipse.mita.base/src/org/eclipse/mita/base/expressions/inferrer/ExpressionsTypeInferrer.java
@@ -242,8 +242,13 @@ public class ExpressionsTypeInferrer extends AbstractTypeSystemInferrer implemen
 	public InferenceResult doInfer(ElementReferenceExpression e) {
 		if (e.isOperationCall()) {
 			if (e.getReference() != null && !e.getReference().eIsProxy()) {
-				return inferOperation(e, (Operation) e.getReference(),
-						Maps.<TypeParameter, InferenceResult>newHashMap());
+				if(e.getReference() instanceof Operation) {
+					return inferOperation(e, (Operation) e.getReference(),
+							Maps.<TypeParameter, InferenceResult>newHashMap());
+				}
+				else {
+					return inferTypeDispatch(e.getReference());
+				}
 			} else {
 				return getAnyType();
 			}

--- a/bundles/org.eclipse.mita.cli/src/org/eclipse/mita/cli/loader/StandaloneTypesGlobalScopeProvider.xtend
+++ b/bundles/org.eclipse.mita.cli/src/org/eclipse/mita/cli/loader/StandaloneTypesGlobalScopeProvider.xtend
@@ -42,7 +42,7 @@ class StandaloneTypesGlobalScopeProvider extends TypesGlobalScopeProvider {
 			result.add(uri);
 		}
 		
-		val objDescriptions = (libraryProvider.getDefaultLibraries() + libraryProvider.getImportedLibraries(context)).flatMap[
+		val objDescriptions = (libraryProvider.getDefaultLibraries() + libraryProvider.getImportedLibraries(context)).toSet.flatMap[
 			val resource = context.resourceSet.getResource(it, true);
 			val resourceServiceProvider = serviceProviderRegistry.getResourceServiceProvider(it);
 			


### PR DESCRIPTION
About ExpressionsTypeInferrer: the type inferrer assumed that the reference is always a operation (which is not the case in case of e.g. Sum Type Constructors).

Fixes #170